### PR TITLE
fix: add VOLUME to Dockerfile to maintain compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=compile-image /usr/bin/terragrunt /usr/bin/terragrunt
 COPY --from=compile-image /etc/poetry /etc/poetry
 
 ENV PATH="/etc/poetry/bin:/opt/venv/bin:$PATH"
+VOLUME /var/lib/docker
 
 RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y --no-install-recommends make bash
 


### PR DESCRIPTION
* AWS CodeBuild is updating the operating system used for the CodeBuild's build fleet from Amazon Linux 1 to Amazon Linux 2
* To ensure your custom Docker images can continue to run after the storage driver upgrade, please validate that your Dockerfile includes the following parameter: VOLUME /var/lib/docker